### PR TITLE
Int 1310 ruby onfleet fix tests

### DIFF
--- a/lib/resources/workers.rb
+++ b/lib/resources/workers.rb
@@ -73,7 +73,7 @@ module Onfleet
       Onfleet.request(config, method.to_sym, path, body.to_json)
     end
 
-    def get_delivery_manifest(config, body, google_api_key, query_parameters_hash)
+    def get_delivery_manifest(config, body, google_api_key = nil, query_parameters_hash = nil)
       method = 'post'
       query_parameters = nil
       

--- a/lib/test/test_data.json
+++ b/lib/test/test_data.json
@@ -1997,9 +1997,9 @@
                 ]
             }
         },
-        "getManifestProvider": {
+        "get_delivery_manifest": {
             "request": {
-                "path": "providers/manifest/generate?hubId=<hubId>&workerId=<workerId>",
+                "path": "providers/manifest/generate?hubId=kyfYe*wyVbqfomP2HTn5dAe1&workerId=kBUZAb7pREtRn*8wIUCpjnPu",
                 "method": "GET"
             },
             "response": {

--- a/lib/test/test_onfleet.rb
+++ b/lib/test/test_onfleet.rb
@@ -15,6 +15,9 @@ require_relative '../resources/teams'
 require_relative '../resources/webhooks'
 require_relative '../resources/workers'
 
+# WebMock blocks HTTP requests in integration tests, but you can either stub the request or call WebMock.allow_net_connect! to configure the tests to run as normal.
+WebMock.allow_net_connect!
+
 # RSpec configuration setup for unit tests
 RSpec.configure do |config|
   file = File.read('./test_data.json')
@@ -22,7 +25,7 @@ RSpec.configure do |config|
   config.test_data = JSON.parse(file)
 
   config.add_setting :api_variables
-  config.api_variables = Onfleet::Configuration.new("f70dd381f0366c721677fb7e088b83bd","https://staging.onfleet.com/api/v2")
+  config.api_variables = Onfleet::Configuration.new("f70dd381f0366c721677fb7e088b83bd","https://stable1.onfleet.com/api/v2")
 end
 
 # Administrator entity tests


### PR DESCRIPTION
<!---
Loosely inspired by https://keepachangelog.com/en/1.1.0/.

Please add items to their respective section and delete empty sections.
- Added: for new features
- Changed: for changes in existing functionality
- Deprecated: for soon-to-be removed features
- Removed: for now removed features
- Fixed: for any bug fixes
- Security: in case of vulnerabilities
Ideally, each item here will be added into the upcoming release.

DO NOT post internal Onfleet links (e.g. Jira/Confluence) –this is a public space.
-->

**Describe the solution**
Fixes for testing the Delivery Manifest API Endpoint. Also WebMock blocks HTTP requests in integration tests so `WebMock.allow_net_connect!` was added to `test_onfleet.rb`

---

**Added**

- Configure google_api_key and query_parameters_hash as optional query parameters
- Fix Delivery Manifest test
- Added `WebMock.allow_net_connect!` to fix running tests error.

**Changed**

**Deprecated**

**Removed**

**Fixed**

**Security**