### PR TITLE
Prepare for v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ Added
 ## [1.0.4](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.4) - 2024-05-29
 Added
 * Added support for Worker's Route Delivery Manifest
+
+## [1.0.5](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.5) - 2024-06-26
+Added
+* Update to RubyGems release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@onfleet/ruby-onfleet",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Onfleet's Ruby API wrapper package",
     "main": "onfleet.rb",
     "scripts": {

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ruby-onfleet'
-  s.version     = '1.0.4'
+  s.version     = '1.0.5'
   s.date        = '2024-06-10'
   s.summary     = 'Onfleet Ruby API wrapper package'
   s.description = 'The Onfleet Ruby library provides convenient access to the Onfleet API.'


### PR DESCRIPTION
## [1.0.5](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.5) - 2024-06-26
Added
* Update to RubyGems release