### PR TITLE
[chore] bump faraday version

### DIFF
--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.metadata    = { 'source_code_uri' => 'https://github.com/onfleet/ruby-onfleet' }
 
-  s.add_dependency('faraday', '~> 2.9.0')
+  s.add_dependency('faraday', '~> 2.14.x')
   s.add_dependency('faraday-net_http', '~> 3.1.0')
   s.add_dependency('faraday-rate_limiter', '~> 0.0.4')
   s.add_dependency('json', '~> 2.6.3')


### PR DESCRIPTION
problem
------

There is currently a security issue with Faraday and `bundle audit` won't pass.

```
Run bundle exec bundle-audit check --update
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db:
  advisories:	1058 advisories
  last updated:	2026-02-11 11:24:37 -0800
  commit:	826ac198fe00af14343d839de644e74bf7d94d84
Name: faraday
Version: 2.9.2
CVE: CVE-2026-25765
GHSA: GHSA-33mh-2634-fwr2
Criticality: Medium
URL: https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2
Title: Faraday affected by SSRF via protocol-relative URL host override in build_exclusive_url
Solution: update to '>= 2.14.1'
```

Faraday 2.14.1 release https://github.com/lostisland/faraday/releases/tag/v2.14.1

Solution
------

Push faraday to at least 2.14.x

Notes
----

I was unable to run tests locally -
```
> ruby lib/test/test_onfleet.rb
<internal:/Users/jon/.rbenv/versions/3.3.6/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- errors/http_error (LoadError)
```

I tried from both the root dir and from `lib`.  I've got to assume i'm doing something wrong so hopefully there is an automated suite that can prove this update doesn't mess up the gem.

Also noticed that there is no `Gemfile.lock`.  When I `bundle update` locally i can see that I indeed get Faraday 2.14.1

```
    faraday (2.14.1)
      faraday-net_http (>= 2.0, < 3.5)
      json
      logger
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `faraday` dependency in `ruby-onfleet.gemspec` to `~> 2.14.x` to fix a security issue.
> 
>   - **Dependencies**:
>     - Update `faraday` dependency in `ruby-onfleet.gemspec` from `~> 2.9.0` to `~> 2.14.x` to address CVE-2026-25765.
>   - **Testing**:
>     - Unable to run tests locally due to `LoadError` for `errors/http_error`. No changes made to address this.
>     - No `Gemfile.lock` present; `bundle update` confirms `faraday` 2.14.1 is installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onfleet%2Fruby-onfleet&utm_source=github&utm_medium=referral)<sup> for bfe1b3462dd6d4fc29712c3575a47644594b7256. You can [customize](https://app.ellipsis.dev/onfleet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->